### PR TITLE
Fix/hpl

### DIFF
--- a/roles/test/defaults/main.yml
+++ b/roles/test/defaults/main.yml
@@ -5,7 +5,7 @@ openhpc_tests_hpl_mem_frac: 0.8
 openhpc_tests_intel_pkgs:
   impi:
     package: intel-mpi-2019.9-912
-    path: /opt/intel/compilers_and_libraries_2020.0.166/linux/mpi/intel64/bin/
+    path: /opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/bin/
   mkl:
     package: intel-mkl-2020.4-912
     path: /opt/intel/compilers_and_libraries_2020.4.304/linux/mkl/bin/

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -36,13 +36,13 @@
       #SBATCH --exclude={{ excluded_nodes | join(',') }}
       {% endif %}
       
-      source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
-      source /opt/intel/compilers_and_libraries/linux/mkl/bin/mklvars.sh intel64
+      source  {{ openhpc_tests_intel_pkgs.impi.path }}/mpivars.sh
+      source {{ openhpc_tests_intel_pkgs.mkl.path }}/mklvars.sh intel64
       export I_MPI_DEBUG=4 # puts Node name in output
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       
       cp $MKLROOT/benchmarks/mp_linpack/HPL.dat .
-      mpirun -perhost 1 -np 1 $MKLROOT/benchmarks/mp_linpack/xhpl_intel64_dynamic -m {{ mem_target }} -b {{ openhpc_tests_hpl_NB }} -p 1 -q 1
+      srun $MKLROOT/benchmarks/mp_linpack/xhpl_intel64_dynamic -m {{ mem_target }} -b {{ openhpc_tests_hpl_NB }} -p 1 -q 1
 
 - name: Run hpl
   shell: sbatch --wait hpl-solo.sh


### PR DESCRIPTION
Turns out intel MPI paths were wrong, but hpl-solo wasn't using them anyway so which mpi/mkl library you got was dependent on what was installed. Which isn't unreasonable as a test in itself but would like to pin to a "known working" version (and fail if that hasn't actually installed). Fixes #12 

Have also swapped hpl-solo to use `srun` launcher given @jovial's problems with mpirun, so fixes #13. This is the same setup hpl-all uses so it's not really adding constraint/complexity.

Tested on a VM cluster.