### PR TITLE
Remove requirement for /opt mount

### DIFF
--- a/roles/test/README.md
+++ b/roles/test/README.md
@@ -13,14 +13,14 @@ Tests (with corresponding tags) are:
 Requirements
 ------------
 
-- Requires a Centos 8 / OpenHPC v2 -based cluster as it uses the Openmpi4 package with UCX provided by v2.
-- `/opt` must be exported from a login node to all compute notes, as software is only installed on the login node. TODO: maybe role should do that and undo it?
+- Requires a Centos 8 / OpenHPC v2 -based cluster as it uses the Openmpi4 package with UCX provided by v2 and requires `dnf`.
 - A filesystem shared across the cluster.
+- `slurm-libpmi-ohpc` to be installed on all nodes
 
 Role Variables
 --------------
 
-- `openhpc_tests_rootdir`: Required, path to directory to use for root of tests. Must be on a cluster shared filesystem. Directory will be created if missing.
+- `openhpc_tests_rootdir`: Required, path to directory to use for root of tests. This must be an absolute path and must be on a cluster shared filesystem. Directory will be created if missing. Test software will be installed in a chroot `installs/` subdirectory.
 - `openhpc_tests_hpl_NB`: Optional, default `192`. The HPL block size "NB" - for Intel CPUs see [here](https://software.intel.com/content/www/us/en/develop/documentation/mkl-linux-developer-guide/top/intel-math-kernel-library-benchmarks/intel-distribution-for-linpack-benchmark/configuring-parameters.html).
 - `openhpc_tests_hpl_mem_frac`: Optional, default `0.8`. The HPL problem size "N" will be selected to target using this fraction of each node's memory.
 - `openhpc_tests_ucx_net_devices`: Optional, default `all`. Control which network device/interface to use, e.g. `mlx5_1:0`, as per `UCX_NET_DEVICES` ([docs](https://github.com/openucx/ucx/wiki/UCX-environment-parameters#setting-the-devices-to-use)). Note the default is probably not what you want.
@@ -33,21 +33,11 @@ A list of other roles hosted on Galaxy should go here, plus any details in regar
 
 Example Playbook
 ----------------
-
-  - hosts: cluster
-    name: Export/mount /opt via NFS for ohcp and intel packages
-    become: yes
+  - hosts: all
+    name: Install slurm-libpmi-ohpc
     tasks:
-      - import_role:
-          name: ansible-role-cluster-nfs
-        vars:
-          nfs_enable:
-            server:  "{{ inventory_hostname in groups['cluster_login'] | first }}"
-            clients: "{{ inventory_hostname in groups['cluster_compute'] }}"
-          nfs_server: "{{ hostvars[groups['cluster_login'] | first ]['server_networks']['ilab'][0] }}"
-          nfs_export: "/opt"
-          nfs_client_mnt_point: "/opt"
-          
+      - yum:
+          name: slurm-libpmi-ohpc
   - hosts: cluster_login[0]
     name: Run tests
     tasks:

--- a/roles/test/tasks/gnu-ompi.yml
+++ b/roles/test/tasks/gnu-ompi.yml
@@ -1,0 +1,21 @@
+- name: Install gnu 9 + openmpi (w/ ucx) + performance tools OHPC packages
+  dnf:
+    name: ohpc-gnu9-openmpi4-perf-tools
+    installroot: "{{ openhpc_tests_rootdir }}/installs"
+  become: yes
+- name: Find modulefiles
+  find:
+    paths:
+      - "{{ openhpc_tests_rootdir }}/installs/opt/ohpc/pub/modulefiles"
+      - "{{ openhpc_tests_rootdir }}/installs/opt/ohpc/pub/moduledeps"
+    file_type: file
+    recurse: yes
+  register: modulefiles
+- name: Rewrite modulefile paths
+  replace:
+    path: "{{ item.path }}"
+    regexp: "(?<!{{ openhpc_tests_rootdir }}/installs)/opt/ohpc" # -ve lookbehind assertion to avoid adding the prefix again when rerunning
+    replace: "{{ openhpc_tests_rootdir }}/installs/opt/ohpc"
+  loop: "{{ modulefiles.files }}"
+  loop_control:
+    label: "{{ item.path }}"  

--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -32,8 +32,8 @@
       #SBATCH --exclusive
       {%if openhpc_tests_nodes is defined %}#SBATCH --nodelist={{ openhpc_tests_nodes }}{% endif %}
       
-      source  {{ openhpc_tests_intel_pkgs.impi.path }}/mpivars.sh
-      source {{ openhpc_tests_intel_pkgs.mkl.path }}/mklvars.sh intel64
+      source  {{ openhpc_tests_rootdir }}/installs/{{ openhpc_tests_intel_pkgs.impi.path }}/mpivars.sh
+      source {{ openhpc_tests_rootdir }}/installs/{{ openhpc_tests_intel_pkgs.mkl.path }}/mklvars.sh intel64
       export I_MPI_DEBUG=4 # puts Node name in output
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       export I_MPI_PMI_LIBRARY=/lib64/libpmi.so # NB: requires slurm-libpmi-ohpc installed

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -36,8 +36,8 @@
       #SBATCH --exclude={{ excluded_nodes | join(',') }}
       {% endif %}
       
-      source  {{ openhpc_tests_intel_pkgs.impi.path }}/mpivars.sh
-      source {{ openhpc_tests_intel_pkgs.mkl.path }}/mklvars.sh intel64
+      source  {{ openhpc_tests_rootdir }}/installs/{{ openhpc_tests_intel_pkgs.impi.path }}/mpivars.sh
+      source {{ openhpc_tests_rootdir }}/installs/{{ openhpc_tests_intel_pkgs.mkl.path }}/mklvars.sh intel64
       export I_MPI_DEBUG=4 # puts Node name in output
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       

--- a/roles/test/tasks/intel.yml
+++ b/roles/test/tasks/intel.yml
@@ -8,8 +8,9 @@
   become: yes
   # TODO: make idempotent
 - name: Install Intel MPI packages
-  yum:
+  dnf:
     name: "{{ item.value.package }}"
+    installroot: "{{ openhpc_tests_rootdir }}/installs"
   become: yes
   loop: "{{ openhpc_tests_intel_pkgs | dict2items }}"
 

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -4,9 +4,9 @@
 # Currently need to run with something like:
 #   ANSIBLE_LIBRARY=. ansible-playbook -i inventory test.yml
 
-- name: Create test root directory
+- name: Create test root and ./installs directories
   file:
-    path: "{{ openhpc_tests_rootdir }}"
+    path: "{{ openhpc_tests_rootdir }}/installs"
     state: directory
     owner: "{{ ansible_user }}"
     mode: 0755

--- a/roles/test/tasks/pingmatrix.yml
+++ b/roles/test/tasks/pingmatrix.yml
@@ -1,7 +1,5 @@
-- name: Install gnu 9 + openmpi (w/ ucx) + performance tools
-  yum:
-    name: ohpc-gnu9-openmpi4-perf-tools
-    state: present
+- name: Add gnu9 + openmpi OHPC packages
+  include: gnu-ompi.yml
   become: yes
 - name: Make directory
   file:
@@ -33,6 +31,7 @@
       {%if openhpc_tests_nodes is defined %}#SBATCH --nodelist={{ openhpc_tests_nodes }}{% endif %}
 
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
+      export MODULEPATH="{{ openhpc_tests_rootdir }}/installs/opt/ohpc/pub/modulefiles"
       module load gnu9/9.3.0
       module load openmpi4/4.0.4
 

--- a/roles/test/tasks/pingpong.yml
+++ b/roles/test/tasks/pingpong.yml
@@ -1,7 +1,5 @@
-- name: Install gnu 9 + openmpi (w/ ucx) + performance tools
-  yum:
-    name: ohpc-gnu9-openmpi4-perf-tools
-    state: present
+- name: Add gnu9 + openmpi OHPC packages
+  include: gnu-ompi.yml
   become: yes
 - name: Make directory
   file:
@@ -23,6 +21,7 @@
       
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
+      export MODULEPATH="{{ openhpc_tests_rootdir }}/installs/opt/ohpc/pub/modulefiles"
       module load gnu9/9.3.0
       module load openmpi4/4.0.4
       module load imb/2019.6


### PR DESCRIPTION
**THIS DOESN'T WORK - PR FOR DISCUSSION**

Currently tests requires /opt to be exported from the headnode and mounted on compute nodes. This is b/c installing s/w on the compute nodes was considered undesirable. However this is pretty odd and doesn't work very nicely with the refactor of the demo repo.

An attempt was made to install into the (already-required cluster shared filesystem) instead using `dnf --installroot {{ openhpc_tests_rootdir }}/installs/` rather than `yum install` (we already require centos8 for tests as we want openhpc v2 for UCX so this is ok).

For the pingpong and pingmatrix tests which use openhpc's openmpi package this also requires:
- rewriting the openhpc modulefiles to reference this new path
- adding `export MODULEPATH="{{ openhpc_tests_rootdir }}/installs/opt/ohpc/pub/modulefiles"`

Having done this PATH and LD_LIBRARY_PATH looks right but both `srun` and `mpirun` are failing with something like:
```
-------------------------------------------------------------------------
Sorry!  You were supposed to get help about:
    opal_init:startup:internal-failure
But I couldn't open the help file:
    /opt/ohpc/pub/mpi/openmpi4-gnu9/4.0.4/share/openmpi/help-opal-runtime.txt: No such file or directory.  Sorry!
```
obvs. the help path is a distraction but implies mpirun doesn't know where it's installed. Tried using an absolute path for mpirun as per docs but that's no different.

For the intel-mpi based HPL-* tests $MKLROOT is hardcoded in `mklvars.sh` script to be:
```
CPRO_PATH=/opt/intel/compilers_and_libraries_2020.4.304/linux
export MKLROOT=${CPRO_PATH}/mkl
```
probably the same thing applies to other vars from e.g. `mpivars.sh`. So all those would need rewriting too. Haven't tried that yet.