### PR TITLE
Remove use of cluster_compute group from test role

### DIFF
--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -6,13 +6,12 @@
     path: "{{ jobdir }}"
     state: directory
     owner: "{{ ansible_user }}"
-- name: Get compute memory (in -megabytes)
-  command: free --mega
-  delegate_to: "{{ groups['cluster_compute'][0] }}"
+- name: Get compute memory (in megabytes)
+  command: "sinfo --noheader --Format Memory --node {{ computes.stdout_lines[0] }}" # first node
   register: free
 - name: Calculate total memory target
   set_fact:
-    mem_target: "{{ (free.stdout_lines[1].split()[1] | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
+    mem_target: "{{ (free.stdout.strip() | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
 - name: "Calculate process grid (P and Q)"
   hpl:
     num_processes: "{{ computes.stdout_lines | length }}"

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -7,12 +7,11 @@
     state: directory
     owner: "{{ ansible_user }}"
 - name: Get compute memory (in megabytes)
-  command: free --mega
-  delegate_to: "{{ groups['cluster_compute'][0] }}"
+  command: "sinfo --noheader --Format Memory --node {{ computes.stdout_lines[0] }}" # first node
   register: free
 - name: Calculate total memory target
   set_fact:
-    mem_target: "{{ (free.stdout_lines[1].split()[1] | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
+    mem_target: "{{ (free.stdout.strip() | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
 - debug:
     msg: "Using 1 process per node targeting {{ mem_target }} MB ({{  openhpc_tests_hpl_mem_frac * 100 }}% of each node)"
 - name: Get all nodes


### PR DESCRIPTION
Test role assumed there was a group cluster_compute - it used first node of this to get memory info to calculate memory target for hpl tests.

Now uses `sinfo` command instead, but this does require slurm to have correct memory info. [This PR](https://github.com/stackhpc/ansible-role-openhpc/pull/81) on the openhpc role adds that by default.