### PR TITLE
Do and reverse /opt export/mount within role

### DIFF
--- a/roles/test/README.md
+++ b/roles/test/README.md
@@ -1,19 +1,17 @@
 stackhpc.slurm_openstack_tools.test
 =========
 
-Tests of MPI functionality on a Slurm-based OpenHPC cluster.
-
-Currently the role assumes there is a single Slurm partition, and tests all the nodes in that partition.
+Tests of MPI functionality on a Slurm-based OpenHPC cluster. Currently it assumes there is a single Slurm partition, and tests some or all of the nodes in that partition.
 
 Tests (with corresponding tags) are:
 - `pingpong`: Runs Intel MPI Benchmark's IMB-MPI1 pingpong between a pair of (scheduler-selected) nodes. Reports zero-size message latency and maximum bandwidth.
 - `pingmatrix`: Runs a similar pingpong test but between all pairs of nodes. Reports zero-size message latency & maximum bandwidth.
 - `hpl-solo`: Runs HPL **separately** on all nodes, using 80% of memory, reporting Gflops on each node. **NB:** Set `openhpc_tests_hpl.NB` as described below.
+- `hpl-all`: Runs HPL on all nodes, using 80% of memory, reporting total Gflops. **NB:** Set `openhpc_tests_hpl.NB` as described below.
 
 See ansible output for summarised results and paths to detailed results files.
 
-For repeatability with minimal impact on compute nodes this role installs the packages required for the tests onto a login node, then exports that node's `/opt` to all other nodes in the play over NFS. 
-This mount is reversed when the tests complete but see the "Cleanup" section below for limitations.
+Note this role is intended as a post-deployment test for a cluster to which you have root access - it should **not** be used on a system running production jobs as they are likely to get broken by the reconfiguration it does. For repeatability with minimal impact on compute nodes it installs the packages required for the tests onto a login node, then exports that node's `/opt` to all other nodes in the play over NFS. This mount is reversed when the tests complete but see the "Cleanup" section below for limitations.
 
 Requirements
 ------------

--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -63,5 +63,6 @@
   register: perf
 - tags: grep2
   debug:
-    #msg: "{{ perf.stdout_lines }}"
-    msg: "{{ perf.stdout_lines[0].split()[6] | float }} Gflops"
+    msg: |
+      Summary for hpl-all:
+      total gflops: {{ perf.stdout_lines[0].split()[6] | float }}

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -79,4 +79,6 @@
     label: "{{ item.split()[6] }}"
 - tags: postpro
   debug:
-    msg: "Mean [{{ computes.stdout_lines | length }} nodes]: {{ gflops_total | float / (computes.stdout_lines | length) }} Gflops"
+    msg: |
+      Summary for hpl-solo ({{ computes.stdout_lines | length }} nodes):
+      mean gflops: {{ gflops_total | float / (computes.stdout_lines | length) }}

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # NB: this only works on centos 8 / ohpc v2 as we want UCX
 # TODO: add support for groups/partitions
-# Currently need to run with something like:
-#   ANSIBLE_LIBRARY=. ansible-playbook -i inventory test.yml
+
+# Cleanup limitations: app packages not removed from login, nfs packages aren't removed from all hosts (might have been installed for something else), exports isn't reverted
 
 - name: Create test root directory
   file:
@@ -11,7 +11,22 @@
     owner: "{{ ansible_user }}"
     mode: 0755
   become: yes
-  tags: always
+  run_once: yes
+  tags: always, setup
+
+- name: Export/mount login's /opt over nfs
+  import_role:
+    name: stackhpc.nfs
+  vars:
+    nfs_enable:
+      server: "{{ true if ansible_hostname == openhpc_slurm_login else false }}"
+      clients: "{{ true if ansible_hostname != openhpc_slurm_login else false }}"
+    nfs_server: "{{ openhpc_slurm_login }}"
+    nfs_export: "/opt"
+    nfs_client_mnt_point: "/opt"
+    nfs_client_mnt_state: "mounted"
+  tags: always, setup
+  become: yes
 
 - name: Get info about compute nodes
   shell: "sinfo --Node --noheader{%if openhpc_tests_nodes is defined %} --nodes {{openhpc_tests_nodes}}{% endif %} --format %N"
@@ -20,6 +35,7 @@
   changed_when: false
   tags: always
   failed_when: computes.rc != 0 or (computes.stdout_lines | length == 0)
+  run_once: yes
 
 - name: IMB PingPong (2x scheduler-selected nodes)
   block:
@@ -27,13 +43,15 @@
   tags: pingpong
   vars:
     jobdir: "{{ openhpc_tests_rootdir }}/pingpong"
+  when: inventory_hostname == openhpc_slurm_login
 
-- name: Ping matrix (all nodes)
+- name: Ping matrix (all selected nodes)
   block:
     - include: pingmatrix.yml
   tags: pingmatrix
   vars:
     jobdir: "{{ openhpc_tests_rootdir }}/pingmatrix"
+  when: inventory_hostname == openhpc_slurm_login
 
 - name: HPL (individual nodes)
   # NB: This uses the precompiled HPL provided with MKL so runs a single MPI process per node, with TBB threads added automatically by MKL to use all cores
@@ -45,6 +63,7 @@
     jobdir: "{{ openhpc_tests_rootdir }}/hpl-solo"
     impi_ver: 2019.6-088 # NB: not exposing these as role vars as not all work!
     mkl_ver: 2020.0-088
+  when: inventory_hostname == openhpc_slurm_login
 
 - name: HPL (individual nodes)
   # NB: This uses the precompiled HPL provided with MKL so runs a single MPI process per node, with TBB threads added automatically by MKL to use all cores
@@ -56,3 +75,28 @@
     jobdir: "{{ openhpc_tests_rootdir }}/hpl-all"
     impi_ver: 2019.6-088 # NB: not exposing these as role vars as not all work!
     mkl_ver: 2020.0-088
+  when: inventory_hostname == openhpc_slurm_login
+
+- name: Remove /opt mount
+  import_role:
+    name: stackhpc.nfs
+  vars:
+    nfs_enable:
+      server: "{{ true if ansible_hostname == openhpc_slurm_login else false }}"
+      clients: "{{ true if ansible_hostname != openhpc_slurm_login else false }}"
+    nfs_server: "{{ openhpc_slurm_login }}"
+    nfs_export: "/opt"
+    nfs_client_mnt_point: "/opt"
+    nfs_client_mnt_state: "absent"
+  ignore_errors: yes # /opt won't be empty
+  tags: always, cleanup
+  become: yes
+
+- name: Remove /opt export definition
+  lineinfile:
+    path: /etc/exports
+    regexp: '^\/opt\s+'
+    state: absent
+  notify: re-export filesystem # from stackhpc.nfs role
+  tags: always, cleanup
+  become: yes

--- a/roles/test/tasks/pingmatrix.yml
+++ b/roles/test/tasks/pingmatrix.yml
@@ -61,11 +61,14 @@
     dest: "{{ jobdir }}/pingmatrix.html"
     nodes: "{{ slurm_names.stdout_lines | join(',') }}"
   register: nxnlatbw
-- name: Summarise results
-  debug:
-    msg: "{{ nxnlatbw['stats'] }}"
-- name: Fetch html table to /tmp/pingmatrix.html
+- name: Fetch html results table to ansible control host
   fetch:
     src: "{{ jobdir }}/pingmatrix.html"
     dest: /tmp/pingmatrix.html
     flat: yes
+- name: Summarise results
+  debug:
+    msg: |
+      Summary for pingmatrix (pairwise on {{ slurm_names.stdout_lines | length }} nodes):
+      {{ nxnlatbw['stats'] | to_nice_yaml }}
+      Tabular output on ansible control host at {{ jobdir }}/pingmatrix.html

--- a/roles/test/tasks/pingpong.yml
+++ b/roles/test/tasks/pingpong.yml
@@ -42,7 +42,7 @@
   register: run_nodes
 - debug: 
     msg: |
-      Summary:
-        - Nodes: {{ run_nodes.stdout.split()[1] }}
-        - Zero-size msg latency: {{ ping_out['columns']['latency'][0] }} us
-        - Max bandwidth: {{ ping_out['columns']['bandwidth'] | max }} Mbytes/s
+      Summary for pingpong (2x scheduler-selected nodes):
+      nodes: {{ run_nodes.stdout.split()[1] }}
+      zero-size msg latency: {{ ping_out['columns']['latency'][0] }} us
+      max bandwidth: {{ ping_out['columns']['bandwidth'] | max }} Mbytes/s


### PR DESCRIPTION
As an alternative to the failed attempt to install s/w on the shared filesystem (see #15), this PR instead does the export/mount of `/opt` inside the role and also reverses it (and cleans up fstab and /etc/exports).

This is still pretty messy - see the "Cleanup" section of the README - but it does at least work and removes the need for a permanent export of /opt in the refactored demo repo (which isn't really an option IMO).

Note the considerably simplified demo playbook in the README.

I did query the ohpc install using --installroot on the OHPC mailing list, only (private) reply so far was essentially "doesn't look like that will work".

The other option would be to use spack to install packages on the shared filesystem. That is itself not trivial and would be far far slower than doing OHPC package installs, but would mean only the shared filesystem was changed I think.