### PR TITLE
improve reporting of hpl-solo results

### DIFF
--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -58,8 +58,15 @@
   register: passed
   failed_when: "passed.stdout_lines | length != computes.stdout_lines | length"
 - name: Extract performance
+  # example of HPL output block - NB code review shows T/V can start with WR or WC:
+  #   <snip>
+  #   T/V                N    NB     P     Q               Time                 Gflops
+  #   --------------------------------------------------------------------------------
+  #   WC00C2R2      110592   256     1     1            2545.90            3.54199e+02
+  #   HPL_pdgesv() start time Thu Feb 25 19:58:25 2021
+  #   <snip>
   tags: postpro
-  shell: "grep '^W[R|C]' *.out | tr -s ' ' | cut -d ' ' -f 7" # tr -s squeezes multiple spaces to single, then take gfops column
+  shell: "grep '^W[R|C]' *.out | tr -s ' ' | cut -d ' ' -f 7" # tr -s squeezes multiple spaces to single, then take gflops column
   args:
     chdir: "{{ jobdir }}"
   changed_when: false

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -59,25 +59,19 @@
   failed_when: "passed.stdout_lines | length != computes.stdout_lines | length"
 - name: Extract performance
   tags: postpro
-  shell: "grep '^W[R|C]' *.out"
+  shell: "grep '^W[R|C]' *.out | tr -s ' ' | cut -d ' ' -f 7" # tr -s squeezes multiple spaces to single, then take gfops column
   args:
     chdir: "{{ jobdir }}"
   changed_when: false
   register: perf
-- tags: postpro
-  debug:
-    msg: "{{ item[1].split()[0] }}: {{ item[0].split()[6] | float }} Gflops"
-  loop: "{{ perf.stdout_lines | zip(computes.stdout_lines) | list }}"
-  loop_control:
-      label: "{{ item[0].split(':')[0] }}" # filename
-- tags: postpro
-  set_fact:
-    gflops_total: "{{ gflops_total | default(0.0) | int + item.split()[6] | float }}"
-  loop: "{{ perf.stdout_lines }}"
-  loop_control:
-    label: "{{ item.split()[6] }}"
-- tags: postpro
+- name: Summarise results
+  tags: postpro
   debug:
     msg: |
       Summary for hpl-solo ({{ computes.stdout_lines | length }} nodes):
-      mean gflops: {{ gflops_total | float / (computes.stdout_lines | length) }}
+        Max:  {{ perf.stdout_lines | map('float') | max }} gflops
+        Min:  {{ perf.stdout_lines | map('float') | min }} gflops
+        Mean: {{ (perf.stdout_lines | map('float') | sum) /  (computes.stdout_lines | length) }} gflops
+
+      Individual node results (gflops):
+      {{ dict(computes.stdout_lines | zip(perf.stdout_lines | map('float') )) | to_nice_yaml }}


### PR DESCRIPTION
Improves output from hpl-solo - was very spaced-out before due to using a loop to report results so hard to see individual node results. Now also adds min and max values.

Note this isn't really intended to provide "pretty" results but there is some value in being able to read them more easily, especially for larger clusters.