### PR TITLE
Make it clearer which hpl test is running

### DIFF
--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -40,7 +40,7 @@
       cp $MKLROOT/benchmarks/mp_linpack/HPL.dat .
       srun $MKLROOT/benchmarks/mp_linpack/xhpl_intel64_dynamic -m {{ mem_target }} -b {{ openhpc_tests_hpl_NB }} -p {{ pq.grid.P }} -q {{ pq.grid.Q }}
 
-- name: Run hpl
+- name: Run hpl-all
   shell: sbatch --wait hpl-all.sh
   become: no
   register:

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -43,7 +43,7 @@
       cp $MKLROOT/benchmarks/mp_linpack/HPL.dat .
       srun $MKLROOT/benchmarks/mp_linpack/xhpl_intel64_dynamic -m {{ mem_target }} -b {{ openhpc_tests_hpl_NB }} -p 1 -q 1
 
-- name: Run hpl
+- name: Run hpl-solo
   shell: sbatch --wait hpl-solo.sh
   become: no
   register:


### PR DESCRIPTION
Simply changes `name:` of both HPL tasks, currently it's v hard to see which one is running!