### PR TITLE
Fix /opt mount for tests

### DIFF
--- a/roles/test/tasks/cleanup.yml
+++ b/roles/test/tasks/cleanup.yml
@@ -1,0 +1,13 @@
+- name: Unmount application directories
+  command:
+    cmd: "umount {{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  become: yes
+  when: ansible_hostname != openhpc_slurm_login
+
+- name: Unexport application directories
+  command:
+    cmd: "exportfs -u *:{{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  become: yes
+  when: ansible_hostname == openhpc_slurm_login

--- a/roles/test/tasks/foss.yml
+++ b/roles/test/tasks/foss.yml
@@ -1,0 +1,4 @@
+- name: Install gnu 9 + openmpi (w/ ucx) + performance tools
+  yum:
+    name: ohpc-gnu9-openmpi4-perf-tools
+    state: present

--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -1,6 +1,3 @@
-- name: Add Intel packages
-  include: intel.yml
-  become: yes
 - name: Make directory
   file:
     path: "{{ jobdir }}"

--- a/roles/test/tasks/hpl-all.yml
+++ b/roles/test/tasks/hpl-all.yml
@@ -8,13 +8,13 @@
   register: free
 - name: Calculate total memory target
   set_fact:
-    mem_target: "{{ (free.stdout.strip() | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
+    mem_target: "{{ (free.stdout.strip() | int * ( openhpc_tests_hpl_mem_frac | float ) ) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
 - name: "Calculate process grid (P and Q)"
   hpl:
     num_processes: "{{ computes.stdout_lines | length }}"
   register: pq
 - debug:
-    msg: "Using P={{ pq.grid.P }} Q={{ pq.grid.Q }} for {{ computes.stdout_lines | length }} processes targeting {{ mem_target }} MB ({{  openhpc_tests_hpl_mem_frac * 100 }}% of each node)"
+    msg: "Using P={{ pq.grid.P }} Q={{ pq.grid.Q }} for {{ computes.stdout_lines | length }} processes targeting {{ mem_target }} MB ({{  ( openhpc_tests_hpl_mem_frac | float ) * 100 }}% of each node)"
 - name: Create sbatch script
   copy:
     dest: "{{ jobdir }}/hpl-all.sh"

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -1,6 +1,3 @@
-- name: Add Intel packages
-  include: intel.yml
-  become: yes
 - name: Make directory
   file:
     path: "{{ jobdir }}"

--- a/roles/test/tasks/hpl-solo.yml
+++ b/roles/test/tasks/hpl-solo.yml
@@ -8,9 +8,9 @@
   register: free
 - name: Calculate total memory target
   set_fact:
-    mem_target: "{{ (free.stdout.strip() | int *  openhpc_tests_hpl_mem_frac) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
+    mem_target: "{{ (free.stdout.strip() | int * (openhpc_tests_hpl_mem_frac | float) ) | int }}" # Intel don't tell you but the -b flag appears to be per node or process, not total!
 - debug:
-    msg: "Using 1 process per node targeting {{ mem_target }} MB ({{  openhpc_tests_hpl_mem_frac * 100 }}% of each node)"
+    msg: "Using 1 process per node targeting {{ mem_target }} MB ({{  (openhpc_tests_hpl_mem_frac | float) * 100 }}% of each node)"
 - name: Get all nodes
   shell: "sinfo --Node --noheader --format %N" # TODO: assumes only one partition, although actually excluding nodes not in the default partition should be fine.
   register: all_nodes

--- a/roles/test/tasks/intel.yml
+++ b/roles/test/tasks/intel.yml
@@ -2,14 +2,11 @@
   command: yum-config-manager --add-repo https://yum.repos.intel.com/setup/intelproducts.repo
   args:
     creates: /etc/yum.repos.d/intelproducts.repo
-  become: yes
 - name: Import Intel GPG keys
   command: rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
-  become: yes
   # TODO: make idempotent
-- name: Install Intel MPI packages
+- name: Install Intel packages
   yum:
     name: "{{ item.value.package }}"
-  become: yes
   loop: "{{ openhpc_tests_intel_pkgs | dict2items }}"
 

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -2,7 +2,7 @@
 # NB: this only works on centos 8 / ohpc v2 as we want UCX
 # TODO: add support for groups/partitions
 
-# Cleanup limitations: app packages not removed from login, nfs packages aren't removed from all hosts (might have been installed for something else), exports isn't reverted
+# Cleanup limitations: app packages not removed from login, nfs packages aren't removed from all hosts (might have been installed for something else)
 
 - name: Create test root directory
   file:

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -4,62 +4,9 @@
 
 # Cleanup limitations: app packages not removed from login, nfs packages aren't removed from all hosts (might have been installed for something else)
 
-- name: Create test root directory
-  file:
-    path: "{{ openhpc_tests_rootdir }}"
-    state: directory
-    owner: "{{ ansible_user }}"
-    mode: 0755
-  become: yes
-  run_once: yes
-  tags: always, setup
-
-- name: Install nfs packages
-  yum:
-    name: nfs-utils
-    state: present
-  become: yes
-  tags: always, setup # TODO: add this to more
-
-- name: Temporarily export application directores from login
-  command:
-    cmd: "exportfs -o rw,insecure,no_root_squash *:{{ item }}"
-  loop: "{{ openhpc_tests_app_dirs }}"
-  become: yes
-  when: ansible_hostname == openhpc_slurm_login
-  # NB is exporting directories which don't exist ok?
-
-- name: Ensure nfs services are running
-  service:
-    name: nfs-server
-    state: started
-  become: yes
-  when: ansible_hostname == openhpc_slurm_login
-
-- name: Ensure application directories exist
-  file:
-    path: "{{ item }}"
-    state: directory
-    # assumes the parent exists, that's ok here
-  loop: "{{ openhpc_tests_app_dirs }}"
-  become: yes
-  when: ansible_hostname != openhpc_slurm_login
-
-- name: Temporarily mount application directories
-  command:
-    cmd: "mount -t nfs {{ openhpc_slurm_login }}:{{ item }} {{ item }}"
-  loop: "{{ openhpc_tests_app_dirs }}"
-  become: yes
-  when: ansible_hostname != openhpc_slurm_login
-
-- name: Get info about compute nodes
-  shell: "sinfo --Node --noheader{%if openhpc_tests_nodes is defined %} --nodes {{openhpc_tests_nodes}}{% endif %} --format %N"
-  register:
-    computes
-  changed_when: false
+- import_tasks: setup.yml
   tags: always
-  failed_when: computes.rc != 0 or (computes.stdout_lines | length == 0)
-  run_once: yes
+  become: yes
 
 - name: IMB PingPong (2x scheduler-selected nodes)
   block:
@@ -101,16 +48,6 @@
     mkl_ver: 2020.0-088
   when: inventory_hostname == openhpc_slurm_login
 
-- name: Unmount application directories
-  command:
-    cmd: "umount {{ item }}"
-  loop: "{{ openhpc_tests_app_dirs }}"
-  become: yes
-  when: ansible_hostname != openhpc_slurm_login
-
-- name: Unexport application directories
-  command:
-    cmd: "exportfs -u *:{{ item }}"
-  loop: "{{ openhpc_tests_app_dirs }}"
-  become: yes
-  when: ansible_hostname == openhpc_slurm_login
+# - import_tasks: cleanup.yml
+#   tags: always
+#   become: yes

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -14,19 +14,43 @@
   run_once: yes
   tags: always, setup
 
-- name: Export/mount login's /opt over nfs
-  import_role:
-    name: stackhpc.nfs
-  vars:
-    nfs_enable:
-      server: "{{ true if ansible_hostname == openhpc_slurm_login else false }}"
-      clients: "{{ true if ansible_hostname != openhpc_slurm_login else false }}"
-    nfs_server: "{{ openhpc_slurm_login }}"
-    nfs_export: "/opt"
-    nfs_client_mnt_point: "/opt"
-    nfs_client_mnt_state: "mounted"
-  tags: always, setup
+- name: Install nfs packages
+  yum:
+    name: nfs-utils
+    state: present
   become: yes
+  tags: always, setup # TODO: add this to more
+
+- name: Temporarily export application directores from login
+  command:
+    cmd: "exportfs -o rw,insecure,no_root_squash *:{{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  become: yes
+  when: ansible_hostname == openhpc_slurm_login
+  # NB is exporting directories which don't exist ok?
+
+- name: Ensure nfs services are running
+  service:
+    name: nfs-server
+    state: started
+  become: yes
+  when: ansible_hostname == openhpc_slurm_login
+
+- name: Ensure application directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    # assumes the parent exists, that's ok here
+  loop: "{{ openhpc_tests_app_dirs }}"
+  become: yes
+  when: ansible_hostname != openhpc_slurm_login
+
+- name: Temporarily mount application directories
+  command:
+    cmd: "mount -t nfs {{ openhpc_slurm_login }}:{{ item }} {{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  become: yes
+  when: ansible_hostname != openhpc_slurm_login
 
 - name: Get info about compute nodes
   shell: "sinfo --Node --noheader{%if openhpc_tests_nodes is defined %} --nodes {{openhpc_tests_nodes}}{% endif %} --format %N"
@@ -77,26 +101,16 @@
     mkl_ver: 2020.0-088
   when: inventory_hostname == openhpc_slurm_login
 
-- name: Remove /opt mount
-  import_role:
-    name: stackhpc.nfs
-  vars:
-    nfs_enable:
-      server: "{{ true if ansible_hostname == openhpc_slurm_login else false }}"
-      clients: "{{ true if ansible_hostname != openhpc_slurm_login else false }}"
-    nfs_server: "{{ openhpc_slurm_login }}"
-    nfs_export: "/opt"
-    nfs_client_mnt_point: "/opt"
-    nfs_client_mnt_state: "absent"
-  ignore_errors: yes # /opt won't be empty
-  tags: always, cleanup
+- name: Unmount application directories
+  command:
+    cmd: "umount {{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
   become: yes
+  when: ansible_hostname != openhpc_slurm_login
 
-- name: Remove /opt export definition
-  lineinfile:
-    path: /etc/exports
-    regexp: '^\/opt\s+'
-    state: absent
-  notify: re-export filesystem # from stackhpc.nfs role
-  tags: always, cleanup
+- name: Unexport application directories
+  command:
+    cmd: "exportfs -u *:{{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
   become: yes
+  when: ansible_hostname == openhpc_slurm_login

--- a/roles/test/tasks/main.yml
+++ b/roles/test/tasks/main.yml
@@ -48,6 +48,6 @@
     mkl_ver: 2020.0-088
   when: inventory_hostname == openhpc_slurm_login
 
-# - import_tasks: cleanup.yml
-#   tags: always
-#   become: yes
+- import_tasks: cleanup.yml
+  tags: always
+  become: yes

--- a/roles/test/tasks/pingmatrix.yml
+++ b/roles/test/tasks/pingmatrix.yml
@@ -1,8 +1,3 @@
-- name: Install gnu 9 + openmpi (w/ ucx) + performance tools
-  yum:
-    name: ohpc-gnu9-openmpi4-perf-tools
-    state: present
-  become: yes
 - name: Make directory
   file:
     path: "{{ jobdir }}"

--- a/roles/test/tasks/pingpong.yml
+++ b/roles/test/tasks/pingpong.yml
@@ -1,8 +1,3 @@
-- name: Install gnu 9 + openmpi (w/ ucx) + performance tools
-  yum:
-    name: ohpc-gnu9-openmpi4-perf-tools
-    state: present
-  become: yes
 - name: Make directory
   file:
     path: "{{ jobdir }}"

--- a/roles/test/tasks/setup.yml
+++ b/roles/test/tasks/setup.yml
@@ -1,0 +1,62 @@
+---
+
+- name: gather facts if missing
+  setup:
+  when: ansible_facts == {}
+
+- name: Add Intel packages
+  include_tasks: intel.yml
+  when: ansible_hostname == openhpc_slurm_login
+
+- name: Add FOSS toolchain packages
+  include_tasks: foss.yml
+  when: ansible_hostname == openhpc_slurm_login
+
+- name: Create test root directory
+  file:
+    path: "{{ openhpc_tests_rootdir }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    mode: 0755
+  run_once: yes
+
+- name: Install nfs packages
+  yum:
+    name: nfs-utils
+    state: present
+
+- name: Temporarily export application directores from login
+  command:
+    cmd: "exportfs -o rw,insecure,no_root_squash *:{{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  when: ansible_hostname == openhpc_slurm_login
+  # safe to re-run
+
+- name: Ensure nfs services are running
+  service:
+    name: nfs-server
+    state: started
+  when: ansible_hostname == openhpc_slurm_login
+
+- name: Ensure application directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    # assumes the parent exists, that's ok here
+  loop: "{{ openhpc_tests_app_dirs }}"
+  when: ansible_hostname != openhpc_slurm_login
+
+- name: Temporarily mount application directories
+  command:
+    cmd: "mount -t nfs {{ openhpc_slurm_login }}:{{ item }} {{ item }}"
+  loop: "{{ openhpc_tests_app_dirs }}"
+  when: ansible_hostname != openhpc_slurm_login
+  # safe to re-run
+
+- name: Get info about compute nodes
+  shell: "sinfo --Node --noheader{%if openhpc_tests_nodes is defined %} --nodes {{openhpc_tests_nodes}}{% endif %} --format %N"
+  register:
+    computes
+  changed_when: false
+  failed_when: computes.rc != 0 or (computes.stdout_lines | length == 0)
+  run_once: yes

--- a/roles/test/vars/main.yml
+++ b/roles/test/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 # vars file for openhpc_tests
+openhpc_tests_app_dirs:
+  - /opt/intel
+  - /opt/ohpc


### PR DESCRIPTION
Need to solve #21 (unmount not actually happening) and the fact that the /opt mount overrides the whole of /opt rather than just /opt/intel and /opt/ohpc which means it breaks e.g. the slurm-stats tools which are also in /opt, as documented in slurm appliance issue [35](https://github.com/stackhpc/openhpc-demo/pull/35).

Plan is to not use our nfs role as this can't do temporary mounts/exports (the former due to use of ansible's `mount` module which can't do temporary mounts either).