### PR TITLE
Add validation

### DIFF
--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -11,7 +11,7 @@
       source {{ openhpc_rebuild_clouds }}
       openstack token issue
     changed_when: false
-    no_log: True
+    no_log: true
   delegate_to: localhost
   delegate_facts: true
   run_once: true

--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -1,0 +1,16 @@
+- block:
+  - stat:
+      path: "{{ openhpc_rebuild_clouds }}"
+    register: openhpc_clouds_path
+  - name: Check OpenRC file (openhpc_rebuild_clouds) exists
+    assert:
+      that: openhpc_clouds_path.stat.exists
+      fail_msg: "openrc file {{ openhpc_rebuild_clouds }} on localhost (specified by `openhpc_rebuild_clouds`) does not exist"
+  - name: Check OpenRC file (openhpc_rebuild_clouds) is usable
+    shell: |
+      source {{ openhpc_rebuild_clouds }}
+      openstack token issue
+    changed_when: false
+  delegate_to: localhost
+  delegate_facts: true
+  run_once: true

--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -11,6 +11,7 @@
       source {{ openhpc_rebuild_clouds }}
       openstack token issue
     changed_when: false
+    no_log: True
   delegate_to: localhost
   delegate_facts: true
   run_once: true


### PR DESCRIPTION
Needs to be done inside the role as then the role default `openhpc_rebuild_clouds` is available.

Note if you're running this role you have openstack, so no need to check for that here (will need to check in slurm appliance).