### PR TITLE
Fixes for openhpc v2.1

### DIFF
--- a/roles/test/tasks/pingmatrix.yml
+++ b/roles/test/tasks/pingmatrix.yml
@@ -28,10 +28,12 @@
       {%if openhpc_tests_nodes is defined %}#SBATCH --nodelist={{ openhpc_tests_nodes }}{% endif %}
 
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
-      module load gnu9/9.3.0
-      module load openmpi4/4.0.4
+      module load gnu9
+      module load openmpi4
 
-      srun --mpi=pmix_v3 nxnlatbw    
+      #srun --mpi=pmix_v3 nxnlatbw # doesn't work in ohpc v2.1
+      mpirun nxnlatbw
+
 - name: Run ping matrix
   shell: sbatch --wait pingmatrix.sh
   become: no

--- a/roles/test/tasks/pingmatrix.yml
+++ b/roles/test/tasks/pingmatrix.yml
@@ -28,10 +28,12 @@
       {%if openhpc_tests_nodes is defined %}#SBATCH --nodelist={{ openhpc_tests_nodes }}{% endif %}
 
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
-      module load gnu9/9.3.0
-      module load openmpi4/4.0.4
+      module load gnu9
+      module load openmpi4
 
-      srun --mpi=pmix_v3 nxnlatbw    
+      srun --mpi=pmix_v3 nxnlatbw # doens't work in ohpc v2.1
+      mpirun nxnlatbw
+      
 - name: Run ping matrix
   shell: sbatch --wait pingmatrix.sh
   become: no

--- a/roles/test/tasks/pingpong.yml
+++ b/roles/test/tasks/pingpong.yml
@@ -18,11 +18,13 @@
       
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
-      module load gnu9/9.3.0
-      module load openmpi4/4.0.4
-      module load imb/2019.6
+      module load gnu9
+      module load openmpi4
+      module load imb
 
-      srun --mpi=pmix_v3 IMB-MPI1 pingpong
+      #srun --mpi=pmi2 IMB-MPI1 pingpong # doesn't work in ohpc v2.1
+      mpirun IMB-MPI1 pingpong
+
 - name: Run pingpong
   shell: sbatch --wait ping.sh
   become: no

--- a/roles/test/tasks/pingpong.yml
+++ b/roles/test/tasks/pingpong.yml
@@ -18,11 +18,13 @@
       
       export UCX_NET_DEVICES={{ openhpc_tests_ucx_net_devices }}
       echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
-      module load gnu9/9.3.0
-      module load openmpi4/4.0.4
-      module load imb/2019.6
+      module load gnu9
+      module load openmpi4
+      module load imb
 
-      srun --mpi=pmix_v3 IMB-MPI1 pingpong
+      #srun --mpi=pmi2 IMB-MPI1 pingpong # doens't work in ohpc v2.1
+      mpirun IMB-MPI1 pingpong
+      
 - name: Run pingpong
   shell: sbatch --wait ping.sh
   become: no

--- a/roles/test/tasks/setup.yml
+++ b/roles/test/tasks/setup.yml
@@ -58,5 +58,11 @@
   register:
     computes
   changed_when: false
-  failed_when: computes.rc != 0 or (computes.stdout_lines | length == 0)
+  failed_when: computes.rc != 0
+  run_once: yes
+
+- name: Check compute node selection valid
+  assert:
+    that: computes.stdout_lines | length > 0
+    fail_msg: "No nodes selected - was variable `openhpc_tests_nodes` set (correctly)?"
   run_once: yes

--- a/roles/test/tasks/setup.yml
+++ b/roles/test/tasks/setup.yml
@@ -25,18 +25,19 @@
     name: nfs-utils
     state: present
 
+- name: Ensure nfs services are running
+  service:
+    name: nfs-server
+    state: started
+  when: ansible_hostname == openhpc_slurm_login
+
 - name: Temporarily export application directores from login
   command:
     cmd: "exportfs -o rw,insecure,no_root_squash *:{{ item }}"
   loop: "{{ openhpc_tests_app_dirs }}"
   when: ansible_hostname == openhpc_slurm_login
   # safe to re-run
-
-- name: Ensure nfs services are running
-  service:
-    name: nfs-server
-    state: started
-  when: ansible_hostname == openhpc_slurm_login
+  # TODO: see if can use -v to make this idempotent?
 
 - name: Ensure application directories exist
   file:


### PR DESCRIPTION
Firstly remove the minor versions from the module names, as some have changed.

Secondly use `mpirun` instead of `srun` for the openmpi-based tasks, due to openhpc v2.1 not supporting pmix - see https://github.com/openhpc/ohpc/issues/1320.

The `hpl-*` tests don't need changing although they also use `srun`; they use intel MPI and set its `I_MPI_PMI_LIBRARY` environment variable to point to the `pmi` library. This still works on ohpc v2.1