### PR TITLE
Use clouds.yaml consistently in rebuild role

### DIFF
--- a/roles/rebuild/README.md
+++ b/roles/rebuild/README.md
@@ -26,15 +26,7 @@ Role Variables
 - `openhpc_rebuild_reconfigure`: Optional bool, whether to reconfigure Slurm at the end of this role so `scontrol reboot ...` uses the new script. Default `true`.
 - `openhpc_enable.batch`: Set to `true` on compute nodes. Note this is the same variable as used in `stackhpc.openhpc`.
 
-It is recommended that the `openhpc_rebuild_clouds` is an [application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html). This can be created in Horizon via Identity > Application Credentials > +Create Application Credential. The usual role required is `member`. Access rules (if using Train or above) can be as below or similar:
-
-```yaml
-- service: compute
-  method: POST
-  path: /v2.1/servers
-```
-
-Note that the downloaded credential can be encrpyted using `ansible-vault` to allow commit to source control. It will automatically be decrypted when copied onto the compute nodes.
+It is recommended that the `openhpc_rebuild_clouds` is an [application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html). This can be created in Horizon via Identity > Application Credentials > +Create Application Credential. The usual role required is `member`. Using access rules has been found not to work at present. Note that the downloaded credential can be encrpyted using `ansible-vault` to allow commit to source control. It will automatically be decrypted when copied onto the compute nodes.
 
 Dependencies
 ------------

--- a/roles/rebuild/README.md
+++ b/roles/rebuild/README.md
@@ -26,13 +26,20 @@ Role Variables
 - `openhpc_rebuild_reconfigure`: Optional bool, whether to reconfigure Slurm at the end of this role so `scontrol reboot ...` uses the new script. Default `true`.
 - `openhpc_enable.batch`: Set to `true` on compute nodes. Note this is the same variable as used in `stackhpc.openhpc`.
 
+It is recommended that the `openhpc_rebuild_clouds` is an [application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html). This can be created in Horizon via Identity > Application Credentials > +Create Application Credential. The usual role required is `member`. Access rules (if using Train or above) can be as below or similar:
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+```yaml
+- service: compute
+  method: POST
+  path: /v2.1/servers
+```
+
+Note that the downloaded credential can be encrpyted using `ansible-vault` to allow commit to source control. It will automatically be decrypted when copied onto the compute nodes.
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+The `stackhpc.openhpc` role.
 
 Example Playbook
 ----------------
@@ -57,4 +64,4 @@ Apache-2.0
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+StackHPC Ltd

--- a/roles/rebuild/README.md
+++ b/roles/rebuild/README.md
@@ -36,17 +36,26 @@ The `stackhpc.openhpc` role.
 Example Playbook
 ----------------
 
-    - hosts: cluster
-      name: Setup openstack rebuild script
-      tags: rebuild
-      become: true
-      tasks:
-        - import_role:
-            name: stackhpc.slurm_openstack_tools.rebuild
-          vars:
-            openhpc_enable:
-              batch: "{{ inventory_hostname in groups['cluster_compute'] }}"
-
+```yaml
+- name: Setup slurm
+  hosts: openhpc
+  become: yes
+  vars:
+    openhpc_enable:
+      batch: "{{ inventory_hostname in groups['cluster_compute'] }}"
+    # NB: see stackpc.openhpc role for its other required vars
+  tasks:
+    - name: Validate application credential for rebuild
+      import_role:
+        name: stackhpc.slurm_openstack_tools.rebuild
+        tasks_from: validate.yml
+    - name: Create slurm cluster
+      import_role:
+        name: stackhpc.openhpc
+    - name: Setup slurm-driven reimage
+      import_role:
+        name: stackhpc.slurm_openstack_tools.rebuild
+```
 
 License
 -------

--- a/roles/rebuild/defaults/main.yml
+++ b/roles/rebuild/defaults/main.yml
@@ -3,3 +3,4 @@ openhpc_rebuild_clouds: ~/.config/openstack/clouds.yaml
 openhpc:
   batch: false
 openhpc_rebuild_reconfigure: true
+openhpc_rebuild_no_log: true

--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -6,6 +6,26 @@
     assert:
       that: openhpc_clouds_path.stat.exists
       fail_msg: "clouds.yaml file {{ openhpc_rebuild_clouds }} on localhost (specified by `openhpc_rebuild_clouds`) does not exist"
+      success_msg: "{{ openhpc_rebuild_clouds }} exists"
+  - name: Read clouds.yaml # handles encrpyted files
+    include_vars:
+      file: "{{ openhpc_rebuild_clouds }}"
+      name: openhpc_rebuild_clouds_content
+    no_log: "{{ openhpc_rebuild_no_log }}"
+  - debug:
+      msg: "{{ openhpc_rebuild_clouds_content }}"
+  - name: Check only one cloud defined
+    assert:
+      that: openhpc_rebuild_clouds_content['clouds'] | length == 1
+      fail_msg: "More than one cloud defined in {{ openhpc_rebuild_clouds }}"
+  - name: Check clouds.yaml works
+    openstack.cloud.auth:
+      # NB: can't use `cloud` parameter due to bug: https://storyboard.openstack.org/#!/story/2008600
+      auth: "{{ openhpc_rebuild_clouds_content['clouds'][cloud_name].auth }}"
+      auth_type: "{{ openhpc_rebuild_clouds_content['clouds'][cloud_name].auth_type }}"
+    vars:
+      cloud_name: "{{ openhpc_rebuild_clouds_content['clouds'] | first }}"
+    register: token
+    no_log: "{{ openhpc_rebuild_no_log }}"
   delegate_to: localhost
-  delegate_facts: true
   run_once: true

--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -12,8 +12,6 @@
       file: "{{ openhpc_rebuild_clouds }}"
       name: openhpc_rebuild_clouds_content
     no_log: "{{ openhpc_rebuild_no_log }}"
-  - debug:
-      msg: "{{ openhpc_rebuild_clouds_content }}"
   - name: Check only one cloud defined
     assert:
       that: openhpc_rebuild_clouds_content['clouds'] | length == 1
@@ -27,5 +25,6 @@
       cloud_name: "{{ openhpc_rebuild_clouds_content['clouds'] | first }}"
     register: token
     no_log: "{{ openhpc_rebuild_no_log }}"
+    become: yes # else get an error "Application credentials cannot request a scope."
   delegate_to: localhost
   run_once: true

--- a/roles/rebuild/tasks/validate.yml
+++ b/roles/rebuild/tasks/validate.yml
@@ -2,16 +2,10 @@
   - stat:
       path: "{{ openhpc_rebuild_clouds }}"
     register: openhpc_clouds_path
-  - name: Check OpenRC file (openhpc_rebuild_clouds) exists
+  - name: Check clouds.yaml file openhpc_rebuild_clouds exists
     assert:
       that: openhpc_clouds_path.stat.exists
-      fail_msg: "openrc file {{ openhpc_rebuild_clouds }} on localhost (specified by `openhpc_rebuild_clouds`) does not exist"
-  - name: Check OpenRC file (openhpc_rebuild_clouds) is usable
-    shell: |
-      source {{ openhpc_rebuild_clouds }}
-      openstack token issue
-    changed_when: false
-    no_log: true
+      fail_msg: "clouds.yaml file {{ openhpc_rebuild_clouds }} on localhost (specified by `openhpc_rebuild_clouds`) does not exist"
   delegate_to: localhost
   delegate_facts: true
   run_once: true


### PR DESCRIPTION
Currently the `rebuild` role is broken as it assumes a clouds.yaml in most of it but an openrc.sh file in validation.

The clouds.yaml assumption is correct, as it allows use of an app cred to reduce the sensitivity of the clouds.yaml file. This PR removes the broken validation (can't use the current method for an app cred) and updates the README with guidance re. using app creds for this.