### PR TITLE
add pytools_gitref so a branch can be installed

### DIFF
--- a/roles/pytools/defaults/main.yml
+++ b/roles/pytools/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for pytools
 pytools_editable: false
+pytools_gitref: master

--- a/roles/pytools/tasks/main.yml
+++ b/roles/pytools/tasks/main.yml
@@ -12,7 +12,7 @@
 
   - name: Create virtualenv
     pip:
-      name: "git+https://github.com/stackhpc/slurm-openstack-tools.git#egg=slurm_openstack_tools"
+      name: "git+https://github.com/stackhpc/slurm-openstack-tools.git@{{ pytools_gitref }}#egg=slurm_openstack_tools"
       editable: "{{ pytools_editable }}"
 
   module_defaults:


### PR DESCRIPTION
Makes it easier to develop/test https://github.com/stackhpc/slurm-openstack-tools by specifying a branch to install using `pytools_gitref`.